### PR TITLE
Add aws credential profile to s3 state configuration

### DIFF
--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -10,12 +10,21 @@ module TfOutputs
           @bucket_name = options[:bucket_name]
           @bucket_key = options[:bucket_key]
           @bucket_region = options[:bucket_region]
-          @profile = options[:profile]
+          @profile = options[:profile] ? options[:profile] : nil
         end
 
         def save
           file = Tempfile.new('tf_state')
-          s3 = Aws::S3::Client.new(region: @bucket_region, profile: @profile)
+
+          # Setup the base client config which must always have a bucket region
+          client_config = {region: @bucket_region}
+          # if a profile was supplied, then add that to the client config
+          if @profile != nil
+            client_config[:profile] = @profile
+          end
+
+          # setup s3 client
+          s3 = Aws::S3::Client.new(client_config)
           resp = s3.get_object bucket: @bucket_name, key: @bucket_key
           file.write(resp.body.string)
           file.rewind

--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -10,11 +10,12 @@ module TfOutputs
           @bucket_name = options[:bucket_name]
           @bucket_key = options[:bucket_key]
           @bucket_region = options[:bucket_region]
+          @profile = options[:profile]
         end
 
         def save
           file = Tempfile.new('tf_state')
-          s3 = Aws::S3::Client.new(region: @bucket_region)
+          s3 = Aws::S3::Client.new(region: @bucket_region, profile: @profile)
           resp = s3.get_object bucket: @bucket_name, key: @bucket_key
           file.write(resp.body.string)
           file.rewind


### PR DESCRIPTION
I have a feeling there is more work to do here, like making sure that the options isn't always required, and I'm going to try to figure out how to test this locally (haven't ever worked on a gem before)

But I wanted to get this conversation started, because I want to use this gem to read tf state, but i'm not using the default aws credential profile in my use case.  I want to be able to specify a different profile so I don't get S3 permissions errors.

It can be common for people to have to manage multiple aws accounts and being able to specify which aws credential profile when using this gem is necessary for them.

