### PR TITLE
AWS credential profile support

### DIFF
--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -19,7 +19,7 @@ module TfOutputs
           # Setup the base client config which must always have a bucket region
           client_config = {region: @bucket_region}
           # if a profile was supplied, then add that to the client config
-          if @profile != nil
+          if !@profile.nil?
             client_config[:profile] = @profile
           end
 

--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -10,12 +10,21 @@ module TfOutputs
           @bucket_name = options[:bucket_name]
           @bucket_key = options[:bucket_key]
           @bucket_region = options[:bucket_region]
-          @profile = options[:profile]
+          @profile = options[:profile] ? options[:profile] : nil
         end
 
         def save
           file = Tempfile.new('tf_state')
-          s3 = Aws::S3::Client.new(region: @bucket_region, profile: @profile)
+
+          # Setup the base client config which must always have a bucket region
+          client_config = {region: @bucket_region}
+          # if a profile was supplied, then add that to the client config
+          if @profile != nil
+            client_config[:profile] = @profile
+          end
+
+          # setup s3 client
+          s3 = Aws::S3::Client.new(client_config)
           resp = s3.get_object bucket: @bucket_name, key: @bucket_key
           file.write(resp.body.string)
           file.rewind

--- a/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
+++ b/lib/tfoutputs/configurator/backends/s3_state_configuration.rb
@@ -10,11 +10,12 @@ module TfOutputs
           @bucket_name = options[:bucket_name]
           @bucket_key = options[:bucket_key]
           @bucket_region = options[:bucket_region]
+          @profile = options[:profile]
         end
 
         def save
           file = Tempfile.new('tf_state')
-          s3 = Aws::S3::Client.new(region: @bucket_region)
+          s3 = Aws::S3::Client.new(region: @bucket_region, profile: @profile)
           resp = s3.get_object bucket: @bucket_name, key: @bucket_key
           file.write(resp.body.string)
           file.rewind


### PR DESCRIPTION
Adding the ability to specify a profile option when setting up the s3 state configuration.  

I work in an environment where I have many different aws keys in my aws credentials file and this is the standard way of narrowing in on a particular set of credentials.